### PR TITLE
fix: Qt6ShaderToolsMacros: handle '@' in shader file paths

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qt6-shadertools (6.8.0-0deepin2) unstable; urgency=medium
+
+  * Add patch: handle '@' in shader file paths (QTBUG-146851).
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Tue, 02 Jun 2026 19:32:21 +0800
+
 qt6-shadertools (6.8.0-0deepin1) unstable; urgency=medium
 
   * New upstream release (6.8.0).

--- a/debian/patches/handle-at-sign-in-shader-file-paths.patch
+++ b/debian/patches/handle-at-sign-in-shader-file-paths.patch
@@ -1,0 +1,113 @@
+Author: Tian Shilin<tianshilin@uniontech.com>
+Date:   Thu May 28 16:50:47 2026
+Subject: Qt6ShaderToolsMacros: handle '@' in shader file paths
+Upstream: https://codereview.qt-project.org/c/qt/qtshadertools/+/736432
+
+
+---
+Index: qt6-shadertools/src/shadertools/doc/src/qtshadertools-build.qdoc
+===================================================================
+--- qt6-shadertools.orig/src/shadertools/doc/src/qtshadertools-build.qdoc
++++ qt6-shadertools/src/shadertools/doc/src/qtshadertools-build.qdoc
+@@ -316,7 +316,9 @@ qt6_add_shaders(exampleapp "exampleapp_s
+     \endcode
+ 
+     The filename can be followed by any number of @-separated
+-    replacement specifications. Each of these specifies the shading
++    replacement specifications. Note that @ characters within the
++    filename or directory path are handled correctly and do not
++    affect the parsing. Each of these specifies the shading
+     language, the version, and the file from which the data is to be
+     read separated by commas. See the \l{QSB Manual} for details.
+ 
+Index: qt6-shadertools/tests/auto/buildtimeqsb/CMakeLists.txt
+===================================================================
+--- qt6-shadertools.orig/tests/auto/buildtimeqsb/CMakeLists.txt
++++ qt6-shadertools/tests/auto/buildtimeqsb/CMakeLists.txt
+@@ -174,3 +174,19 @@ qt6_add_shaders(tst_buildtimeqsb "shader
+         "color_multiview_def.vert.qsb"
+         "color_multiview_def.frag.qsb"
+ )
++
++qt6_add_shaders(tst_buildtimeqsb "shaders_with_at_in_path"
++    PREFIX
++        "/test"
++    FILES
++        "subdir/at@sign/color.frag"
++)
++
++qt6_add_shaders(tst_buildtimeqsb "shaders_with_at_in_path_and_replacements"
++    PREFIX
++        "/test"
++    OUTPUTS
++        "color_at_repl.frag.qsb"
++    FILES
++        "subdir/at@sign/color.frag@glsl,100es,replacements/r4.frag"
++)
+Index: qt6-shadertools/tests/auto/buildtimeqsb/subdir/at@sign/color.frag
+===================================================================
+--- /dev/null
++++ qt6-shadertools/tests/auto/buildtimeqsb/subdir/at@sign/color.frag
+@@ -0,0 +1,12 @@
++#version 440
++
++layout(location = 0) in vec2 v_texcoord;
++
++layout(location = 0) out vec4 fragColor;
++
++layout(binding = 1) uniform sampler2D tex;
++
++void main()
++{
++    fragColor = texture(tex, v_texcoord);
++}
+Index: qt6-shadertools/tools/qsb/Qt6ShaderToolsMacros.cmake
+===================================================================
+--- qt6-shadertools.orig/tools/qsb/Qt6ShaderToolsMacros.cmake
++++ qt6-shadertools/tools/qsb/Qt6ShaderToolsMacros.cmake
+@@ -80,13 +80,39 @@ function(_qt_internal_add_shaders_impl t
+     math(EXPR file_index "0")
+     foreach(file_and_replacements IN LISTS arg_FILES)
+         string(REPLACE "@" ";" file_and_replacement_list "${file_and_replacements}")
+-        list(GET file_and_replacement_list 0 file)
+-        list(LENGTH file_and_replacement_list replacement_count_plus_one)
++        list(LENGTH file_and_replacement_list segment_count)
+         set(qsb_replace_args "")
+-        if(replacement_count_plus_one GREATER 1)
+-            math(EXPR replacement_count "${replacement_count_plus_one}-1")
+-            foreach(replacement_idx RANGE 1 ${replacement_count})
+-                list(GET file_and_replacement_list ${replacement_idx} replacement)
++        math(EXPR segment_max_idx "${segment_count}-1")
++
++        # Walk the @-split segments one by one, accumulating them into a
++        # candidate path. The first candidate ending with a known shader
++        # extension (.vert, .tesc, .tese, .geom, .frag, .comp) is the real
++        # filename; everything after it is the replacement specification.
++        # This handles paths that contain @ characters in directory or file names.
++        set(file "")
++        set(candidate "")
++        foreach(idx RANGE ${segment_max_idx})
++            list(GET file_and_replacement_list ${idx} segment)
++            if(candidate)
++                set(candidate "${candidate}@${segment}")
++            else()
++                set(candidate "${segment}")
++            endif()
++
++            if(candidate MATCHES "\\.(vert|tesc|tese|geom|frag|comp)$")
++                set(file "${candidate}")
++                break()
++            endif()
++        endforeach()
++
++        if(NOT file)
++            set(file "${file_and_replacements}")
++        elseif(NOT file STREQUAL file_and_replacements)
++            string(LENGTH "${file}" file_length)
++            math(EXPR remainder_start "${file_length}+1")
++            string(SUBSTRING "${file_and_replacements}" ${remainder_start} -1 remainder)
++            string(REPLACE "@" ";" replacement_specs "${remainder}")
++            foreach(replacement IN LISTS replacement_specs)
+                 # Get a list, f.ex. "glsl;100es;some/where/shader.frag" so that we can
+                 # adjust the filename (3rd component) to be absolute.
+                 string(REPLACE "," ";" replacement_list "${replacement}")

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+handle-at-sign-in-shader-file-paths.patch


### PR DESCRIPTION
Log: When a shader file path contains '@' characters (e.g. "subdir/at@sign/color.frag"), the '@' was treated unconditionally as the separator between the filename and replacement specifications, causing incorrect parsing. Fix by accumulating segments split on '@' until a valid shader extension is found, rather than assuming the first segment is always the filename.

Upstream: https://codereview.qt-project.org/c/qt/qtshadertools/+/736432